### PR TITLE
Fixed compilation error for several boards

### DIFF
--- a/RF3Sens/Config.h
+++ b/RF3Sens/Config.h
@@ -31,7 +31,8 @@ debug_type = 5  Данные перемещения мышки.
 Для платы Digispark это единственный вариант и автоматически включается на 1 ногу
 Если не определено, для дебага используется Hardware Serial
 */
-#define software_serial 1 // одновременно и признак софтового serial и номер ноги для передачи данных (TX PIN)
+//#define software_serial 1 // одновременно и признак софтового serial и номер ноги для передачи данных (TX PIN)
+#define SERIAL_SPEED 115200
 
 /*
 Тип сенсора, выбрать один нужный
@@ -43,9 +44,9 @@ debug_type = 5  Данные перемещения мышки.
 /*
 Тип контроллера, выбрать один нужный
 */
-//#include "board_Digispark.h"
-//#include "board_ArduinoNano.h" // базовая распайка arduino nano
-#include "board_ArduinoNano_mcupower.h" // распайка сенсора на arduino nano для питания с ног микроконтроллера
+#define DIGI_SPARK
+//#define ARDUINO_NANO // базовая распайка arduino nano
+//#define ARDUINON_NANO_wPOWER  // распайка сенсора на arduino nano для питания с ног микроконтроллера
 
 //###########################################################################################
 //        Конец ручных настроек
@@ -64,6 +65,16 @@ debug_type = 5  Данные перемещения мышки.
 #endif
 #if defined(sens_type_ADNS_2620)
   #include "sensor_ADNS_2620.h"
+#endif
+
+#if defined(DIGI_SPARK)
+#include "board_Digispark.h"
+#endif
+#if defined(ARDUINO_NANO)
+#include "board_ArduinoNano.h"
+#endif
+#if defined(ARDUINON_NANO_wPOWER)
+#include "board_ArduinoNano_mcupower.h"
 #endif
 
 #if defined(debug_type) && defined(software_serial)

--- a/RF3Sens/RF3Sens.ino
+++ b/RF3Sens/RF3Sens.ino
@@ -53,7 +53,7 @@ void setup(){
     pin_SDIO_LOW;
 
 #if defined(debug_type)
-    SERIAL_OUT.begin(115200);
+    SERIAL_OUT.begin(SERIAL_SPEED);
 #endif
 
   delay(1000);
@@ -213,13 +213,13 @@ void loop(){
 // процедуры
 //-------------------------------------------------------------------------------------------
 void ADNS_reset(void){
-#ifdef flg_ADNS_type_ADNS_5020
+#ifdef sens_type_ADNS_5020
   ADNS_write(0x3a,0x5a);
   delay(1000);
   ADNS_write(0x0d, 0x01);  // Set 1000cpi resolution
   delay(1000);
 #endif
-#ifdef flg_ADNS_type_ADNS_2610
+#if  defined(sens_type_ADNS_2610) || defined(sens_type_ADNS_2620)
   //ADNS_write(0x00,0x80);
   delay(1000);
   ADNS_write(0x00,0x01); //Always awake


### PR DESCRIPTION
Исправил ошибки:
1) В функции ADNS_reset(void) были неправильные дефайны и не определен датчик 2620
2) Изменил структуру включения файлов контроллеров через дефайны - теперь компилируется под все типы бордов (кажется)
Также добавил макрос SERIAL_SPEED для изменения скорости порта через файл настроек